### PR TITLE
Adding void type to Promises where needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-eventbridge",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Mock event bridge for serverless offline",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ class ServerlessOfflineEventbridge {
 
     public async listen() {
         let host = this.config.host;
-        return new Promise(res => {
+        return new Promise<void>(res => {
             this.server = this.app.listen({
                 port: this.localPort,
                 host
@@ -175,7 +175,7 @@ class ServerlessOfflineEventbridge {
     }
 
     public async waitForSigint() {
-        return new Promise(res => {
+        return new Promise<void>(res => {
             process.on("SIGINT", () => {
                 this.log("Halting offline-eventbridge server");
                 res();


### PR DESCRIPTION
Addressing this error that comes up in my installation elsewhere:

`Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?`